### PR TITLE
Add heavy test button

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import pandas as pd
 import random
 from datetime import datetime, timedelta, date
 import json
+import subprocess
 from scheduler import build_schedule, build_median_report
 
 # ------------------------------------------------------------------
@@ -337,6 +338,23 @@ if st.button("🚀 Generate Schedule", disabled=False):
     )
     if not unf.empty:
         st.download_button("Download Unfilled CSV", unf.to_csv(index=False), "unfilled.csv")
+
+    # --------------------------------------
+    # Heavy testing button
+    # --------------------------------------
+    if st.button("🧪 Run Heavy Tests", key="btn_heavy_tests"):
+        with st.spinner("Running tests..."):
+            proc = subprocess.run(["pytest", "-q"], capture_output=True, text=True)
+        st.session_state.test_log = proc.stdout + proc.stderr
+
+    if "test_log" in st.session_state:
+        st.text_area("Test Output", st.session_state.test_log, height=300, key="txt_test_output")
+        st.download_button(
+            "Download Test Log",
+            st.session_state.test_log,
+            "test_log.txt",
+            key="btn_dl_test_log",
+        )
 
 
 


### PR DESCRIPTION
## Summary
- allow heavy tests via new button in the Streamlit UI
- expose heavy test output for download

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68722d0722788328b1249707519ad994