### PR TITLE
Add scheduler unit tests

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -49,3 +49,54 @@ def test_build_schedule_simple():
     df, summary, unf = scheduler.build_schedule()
     assert len(df) == 2
     assert unf.empty
+
+
+def test_weekend_balancing_affects_summary():
+    setup_state_simple()
+    # span includes Thu-Fri-Sat to test weekend handling
+    st.session_state.start_date = date(2023, 1, 5)
+    st.session_state.end_date = date(2023, 1, 7)
+    st.session_state.min_gap = 0
+
+    import random
+    random.seed(0)
+    df, summary, unf = scheduler.build_schedule()
+    assert unf.empty
+
+    wk_cols = [c for c in summary.columns if c.endswith("_assigned_weekend")]
+    for col in wk_cols:
+        lbl = col.replace("_assigned_weekend", "")
+        for _, row in summary.iterrows():
+            assert row[col] == row[f"{lbl}_expected_weekend"]
+
+
+def test_build_median_report_simple():
+    data = [
+        {
+            "Name": "A",
+            "Assigned Points": 6,
+            "Shift1_assigned_total": 3,
+            "Shift1_assigned_weekend": 2,
+        },
+        {
+            "Name": "B",
+            "Assigned Points": 2,
+            "Shift1_assigned_total": 1,
+            "Shift1_assigned_weekend": 0,
+        },
+        {
+            "Name": "C",
+            "Assigned Points": 4,
+            "Shift1_assigned_total": 2,
+            "Shift1_assigned_weekend": 1,
+        },
+    ]
+    import pandas as pd
+    df = pd.DataFrame(data)
+    report = scheduler.build_median_report(df)
+    # expect four rows describing deviation from median
+    assert len(report) == 4
+    pts = report[report["Label"] == "Points"].set_index("Name")["Δ Points vs median"].to_dict()
+    assert pts == {"A": 2, "B": -2}
+    shift = report[report["Label"] == "Shift1"].set_index("Name")["Δ Total vs median"].to_dict()
+    assert shift == {"A": 1, "B": -1}


### PR DESCRIPTION
## Summary
- extend scheduler tests for weekend balancing logic
- cover build_median_report behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68722e826bdc832895edf3badd3ccd81