### PR TITLE
Add compact summary output

### DIFF
--- a/app.py
+++ b/app.py
@@ -298,7 +298,21 @@ with st.expander("🔄 Rotators"):
 if st.button("🚀 Generate Schedule", disabled=False):
     random.seed(st.session_state.seed)
     df, wide_summ, unf, compact_summ = build_schedule()
+    st.session_state.df_sched = df
+    st.session_state.df_summary = wide_summ
+    st.session_state.df_unfilled = unf
+    st.session_state.compact_summ = compact_summ
+    FAIR_TOL = 0  # 0 = show every deviation, 1 = ignore ±1
+    st.session_state.median_df = build_median_report(wide_summ, FAIR_TOL)
+    st.session_state.generated = True
     st.success("✅ Schedule generated!")
+
+if st.session_state.get("generated"):
+    df = st.session_state.df_sched
+    wide_summ = st.session_state.df_summary
+    unf = st.session_state.df_unfilled
+    compact_summ = st.session_state.compact_summ
+    median_df = st.session_state.median_df
     st.dataframe(df)
     st.subheader("📊 Compact Summary")
     st.dataframe(compact_summ)
@@ -306,7 +320,7 @@ if st.button("🚀 Generate Schedule", disabled=False):
     st.dataframe(wide_summ)
     # ---------- fairness vs MEDIAN ----------
     FAIR_TOL = 0    # 0 = show every deviation, 1 = ignore ±1
-    median_df = build_median_report(wide_summ, FAIR_TOL)
+    median_df = st.session_state.median_df
 
     if not median_df.empty:
         st.warning("⚖️  Median fairness – residents above / below peer median")

--- a/app.py
+++ b/app.py
@@ -297,14 +297,16 @@ with st.expander("🔄 Rotators"):
 
 if st.button("🚀 Generate Schedule", disabled=False):
     random.seed(st.session_state.seed)
-    df, summ, unf = build_schedule()
+    df, wide_summ, unf, compact_summ = build_schedule()
     st.success("✅ Schedule generated!")
     st.dataframe(df)
-    st.subheader("📊 Assignment Summary")
-    st.dataframe(summ)
+    st.subheader("📊 Compact Summary")
+    st.dataframe(compact_summ)
+    st.subheader("📊 Assignment Summary (wide)")
+    st.dataframe(wide_summ)
     # ---------- fairness vs MEDIAN ----------
     FAIR_TOL = 0    # 0 = show every deviation, 1 = ignore ±1
-    median_df = build_median_report(summ, FAIR_TOL)
+    median_df = build_median_report(wide_summ, FAIR_TOL)
 
     if not median_df.empty:
         st.warning("⚖️  Median fairness – residents above / below peer median")
@@ -322,11 +324,11 @@ if st.button("🚀 Generate Schedule", disabled=False):
         st.warning("⚠️ Unfilled Slots Detected")
         st.dataframe(unf)
     st.download_button("Download Schedule CSV", df.to_csv(index=False), "schedule.csv")
-    st.download_button("Download Summary CSV", summ.to_csv(index=False), "summary.csv")
+    st.download_button("Download Summary CSV", wide_summ.to_csv(index=False), "summary.csv")
     log_data = {
         "config": {k: st.session_state[k] for k in st.session_state if k in def_state or k in ("juniors", "seniors", "seed")},
         "schedule": df.to_dict(orient="records"),
-        "summary": summ.to_dict(orient="records"),
+        "summary": wide_summ.to_dict(orient="records"),
         "unfilled": unf.to_dict(orient="records"),
     }
     st.download_button(


### PR DESCRIPTION
## Summary
- support optional `group_by` arg for `build_schedule`
- generate compact per-resident summaries and optional role/shift aggregates
- display the compact table in the Streamlit app
- update tests with lightweight pandas and streamlit stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722e8527ac8328b55927cc121eeec2