### PR TITLE
Improve fairness reporting and fill unassigned slots

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -196,6 +196,155 @@ def balance_totals(schedule_rows, stats, target_total, min_gap, shift_labels, la
         last_assigned[person] = max(dates) if dates else None
 
 
+def fill_unassigned_shifts(
+    schedule_rows,
+    stats,
+    unfilled,
+    shift_cfg_map,
+    points_assigned,
+    expected_points_total,
+    juniors,
+    seniors,
+    regular_pool,
+    shift_labels,
+    last_assigned,
+    target_total,
+    target_weekend,
+):
+    """Attempt to assign any unfilled shifts to under-scheduled staff."""
+    point_deficit = {p: expected_points_total.get(p, 0) - points_assigned.get(p, 0) for p in regular_pool}
+    new_unfilled = []
+
+    for dt, lbl in unfilled:
+        row_idx = next((i for i, r in enumerate(schedule_rows) if r["Date"] == dt), None)
+        if row_idx is None:
+            continue
+        row = schedule_rows[row_idx]
+        if row.get(lbl) != "Unfilled":
+            continue
+        cfg = shift_cfg_map[lbl]
+        role_pool = juniors if cfg["role"] == "Junior" else seniors
+        role_pool = [p for p in role_pool if p in regular_pool]
+
+        def already_assigned(person):
+            return any(row[l] == person for l in shift_labels if l != lbl)
+
+        def eligible(p):
+            if p not in role_pool:
+                return False
+            if already_assigned(p):
+                return False
+            if on_leave(p, dt) or not is_active_rotator(p, dt):
+                return False
+            if last_assigned[p] is not None and (dt - last_assigned[p]).days < st.session_state.min_gap:
+                return False
+            return True
+
+        total_deficit = {p: target_total.get(lbl, {}).get(p, 0) - stats[p][lbl]["total"] for p in role_pool}
+        wkd_deficit = {p: target_weekend.get(lbl, {}).get(p, 0) - stats[p][lbl]["weekend"] for p in role_pool}
+
+        candidates = [p for p in role_pool if eligible(p)]
+        if not candidates:
+            new_unfilled.append((dt, lbl))
+            continue
+
+        def priority(p):
+            return (
+                wkd_deficit.get(p, 0) if is_weekend(dt, cfg) else 0,
+                total_deficit.get(p, 0),
+                point_deficit.get(p, 0),
+            )
+
+        pick = max(candidates, key=priority)
+        row[lbl] = pick
+        stats[pick][lbl]["total"] += 1
+        if is_weekend(dt, cfg):
+            stats[pick][lbl]["weekend"] += 1
+        points_assigned[pick] += get_shift_points(dt, cfg)
+        last_assigned[pick] = dt
+        point_deficit[pick] = expected_points_total.get(pick, 0) - points_assigned.get(pick, 0)
+
+    return new_unfilled
+
+
+def rebalance_points(
+    schedule_rows,
+    stats,
+    shift_cfg_map,
+    points_assigned,
+    expected_points_total,
+    juniors,
+    seniors,
+    regular_pool,
+    shift_labels,
+    last_assigned,
+    min_gap,
+):
+    """Swap shifts from over-scheduled to under-scheduled staff based on points."""
+
+    all_labels = [lbl for lbl in schedule_rows[0] if lbl not in ("Date", "Day")]
+
+    def point_diff(p):
+        return points_assigned.get(p, 0) - expected_points_total.get(p, 0)
+
+    changed = True
+    while changed:
+        changed = False
+        over = [p for p in regular_pool if point_diff(p) > 0.5]
+        under = [p for p in regular_pool if point_diff(p) < -0.5]
+        if not over or not under:
+            break
+
+        for idx, row in enumerate(schedule_rows):
+            dt = row["Date"]
+            for lbl in shift_labels:
+                person = row.get(lbl)
+                if person not in over:
+                    continue
+                cfg = shift_cfg_map[lbl]
+                role_pool = juniors if cfg["role"] == "Junior" else seniors
+
+                def violates(p):
+                    return (
+                        p not in role_pool
+                        or any(row[l] == p for l in all_labels if l != lbl)
+                        or on_leave(p, dt)
+                        or not is_active_rotator(p, dt)
+                        or (
+                            last_assigned[p] is not None
+                            and (dt - last_assigned[p]).days < min_gap
+                        )
+                    )
+
+                for target in under:
+                    if violates(target):
+                        continue
+
+                    row[lbl] = target
+                    stats[person][lbl]["total"] -= 1
+                    stats[target][lbl]["total"] += 1
+                    if is_weekend(dt, cfg):
+                        stats[person][lbl]["weekend"] -= 1
+                        stats[target][lbl]["weekend"] += 1
+
+                    pts = get_shift_points(dt, cfg)
+                    points_assigned[person] -= pts
+                    points_assigned[target] += pts
+                    last_assigned[target] = dt
+
+                    changed = True
+                    break
+                if changed:
+                    break
+            if changed:
+                break
+
+    for p in last_assigned:
+        dates = [r["Date"] for r in schedule_rows if any(r[l] == p for l in all_labels)]
+        last_assigned[p] = max(dates) if dates else None
+
+
+
 def build_median_report(summary_df: pd.DataFrame, tol: int = 0):
     rows = []
     for col in [c for c in summary_df.columns if c.endswith("_assigned_total")]:
@@ -221,6 +370,38 @@ def build_median_report(summary_df: pd.DataFrame, tol: int = 0):
                     "Name": r["Name"],
                     "Label": "Points",
                     "Δ Points vs median": int(d_pts),
+                })
+    return pd.DataFrame(rows)
+
+
+def build_expectation_report(summary_df: pd.DataFrame, tol: int = 0) -> pd.DataFrame:
+    """Highlight deviations from expected totals, weekends and points."""
+    rows = []
+    records = summary_df.to_dict(orient="records")
+    if not records:
+        return pd.DataFrame(rows)
+
+    cols = getattr(summary_df, "columns", None) or list(records[0].keys())
+    for col in [c for c in cols if c.endswith("_assigned_total")]:
+        label = col.replace("_assigned_total", "")
+        for r in records:
+            d_tot = r[f"{label}_assigned_total"] - r[f"{label}_expected_total"]
+            d_wkd = r[f"{label}_assigned_weekend"] - r[f"{label}_expected_weekend"]
+            if abs(d_tot) > tol or abs(d_wkd) > tol:
+                rows.append({
+                    "Name": r["Name"],
+                    "Label": label,
+                    "Δ Total vs expected": int(d_tot),
+                    "Δ Weekend vs expected": int(d_wkd),
+                })
+    if "Assigned Points" in cols and "Expected Points" in cols:
+        for r in records:
+            d_pts = r["Assigned Points"] - r["Expected Points"]
+            if abs(d_pts) > tol:
+                rows.append({
+                    "Name": r["Name"],
+                    "Label": "Points",
+                    "Δ Points vs expected": int(d_pts),
                 })
     return pd.DataFrame(rows)
 
@@ -426,6 +607,41 @@ def build_schedule(group_by: str | None = None):
         st.session_state.min_gap,
         shift_labels,
         last_assigned,
+    )
+
+    prev = None
+    for _ in range(3):
+        unfilled = fill_unassigned_shifts(
+            schedule_rows,
+            stats,
+            unfilled,
+            {cfg["label"]: cfg for cfg in shifts_cfg},
+            points_assigned,
+            expected_points_total,
+            juniors,
+            seniors,
+            regular_pool,
+            shift_labels,
+            last_assigned,
+            target_total,
+            target_weekend,
+        )
+        if prev is not None and len(unfilled) >= prev:
+            break
+        prev = len(unfilled)
+
+    rebalance_points(
+        schedule_rows,
+        stats,
+        {cfg["label"]: cfg for cfg in shifts_cfg if not cfg["night_float"]},
+        points_assigned,
+        expected_points_total,
+        juniors,
+        seniors,
+        regular_pool,
+        shift_labels,
+        last_assigned,
+        st.session_state.min_gap,
     )
 
     df_schedule = pd.DataFrame(schedule_rows)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -94,3 +94,120 @@ def test_build_schedule_simple():
     assert unf.empty
     assert not wide.empty
     assert not compact.empty
+
+
+def test_build_expectation_report():
+    data = [
+        {
+            "Name": "A",
+            "Shift1_assigned_total": 2,
+            "Shift1_expected_total": 1,
+            "Shift1_assigned_weekend": 1,
+            "Shift1_expected_weekend": 0,
+            "Assigned Points": 3,
+            "Expected Points": 1,
+        },
+        {
+            "Name": "B",
+            "Shift1_assigned_total": 0,
+            "Shift1_expected_total": 1,
+            "Shift1_assigned_weekend": 0,
+            "Shift1_expected_weekend": 1,
+            "Assigned Points": 0,
+            "Expected Points": 2,
+        },
+    ]
+    df = scheduler.pd.DataFrame(data)
+    report = scheduler.build_expectation_report(df)
+    assert len(report) == 4
+
+
+def test_fill_unassigned_shifts_prioritizes_deficit():
+    cfg = {
+        "label": "Shift1",
+        "role": "Junior",
+        "night_float": False,
+        "thur_weekend": False,
+        "points": 1.0,
+    }
+
+    schedule_rows = [{"Date": date(2023, 1, 1), "Day": "Sunday", "Shift1": "Unfilled"}]
+    stats = {
+        "A": {"Shift1": {"total": 0, "weekend": 0}},
+        "B": {"Shift1": {"total": 0, "weekend": 0}},
+    }
+    unfilled = [(date(2023, 1, 1), "Shift1")]
+
+    points_assigned = {"A": 0, "B": 0}
+    expected_points_total = {"A": 0, "B": 0}
+    juniors = ["A", "B"]
+    seniors = []
+    regular_pool = ["A", "B"]
+    shift_labels = ["Shift1"]
+    last_assigned = {"A": None, "B": None}
+    target_total = {"Shift1": {"A": 0, "B": 1}}
+    target_weekend = {"Shift1": {"A": 0, "B": 1}}
+
+    new_unfilled = scheduler.fill_unassigned_shifts(
+        schedule_rows,
+        stats,
+        unfilled,
+        {"Shift1": cfg},
+        points_assigned,
+        expected_points_total,
+        juniors,
+        seniors,
+        regular_pool,
+        shift_labels,
+        last_assigned,
+        target_total,
+        target_weekend,
+    )
+
+    assert new_unfilled == []
+    assert schedule_rows[0]["Shift1"] == "B"
+
+
+def test_rebalance_points_swaps():
+    cfg = {
+        "label": "Shift1",
+        "role": "Junior",
+        "night_float": False,
+        "thur_weekend": False,
+        "points": 1.0,
+    }
+
+    schedule_rows = [
+        {"Date": date(2023, 1, 1), "Day": "Sunday", "Shift1": "A"},
+        {"Date": date(2023, 1, 2), "Day": "Monday", "Shift1": "A"},
+    ]
+
+    stats = {
+        "A": {"Shift1": {"total": 2, "weekend": 0}},
+        "B": {"Shift1": {"total": 0, "weekend": 0}},
+    }
+
+    points_assigned = {"A": 2, "B": 0}
+    expected_points_total = {"A": 1, "B": 1}
+    juniors = ["A", "B"]
+    seniors = []
+    regular_pool = ["A", "B"]
+    shift_labels = ["Shift1"]
+    last_assigned = {"A": date(2023, 1, 2), "B": None}
+
+    scheduler.rebalance_points(
+        schedule_rows,
+        stats,
+        {"Shift1": cfg},
+        points_assigned,
+        expected_points_total,
+        juniors,
+        seniors,
+        regular_pool,
+        shift_labels,
+        last_assigned,
+        0,
+    )
+
+    assigned = [row["Shift1"] for row in schedule_rows]
+    assert assigned.count("B") == 1


### PR DESCRIPTION
## Summary
- fill unassigned shifts iteratively
- rebalance assignments using point deficits
- unit tests for expectation report, fill_unassigned, and rebalance_points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872481523248328a9ba46e37e366957