### PR TITLE
Improve point balance in scheduler

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -131,9 +131,6 @@ def test_weekend_filter_fallback():
     df, _, unf, _ = scheduler.build_schedule()
     assert unf.empty
     assert df._data[0]["Shift1"] == "B"
-
-
-=
 def test_fill_unassigned_shifts_prioritizes_deficit():
     cfg = {
         "label": "Shift1",
@@ -178,4 +175,36 @@ def test_fill_unassigned_shifts_prioritizes_deficit():
 
     assert new_unfilled == []
     assert schedule_rows[0]["Shift1"] == "B"
+
+
+def test_balance_points_basic():
+    setup_state_simple()
+    cfg = st.session_state.shifts[0]
+    shift_cfg_map = {"Shift1": cfg}
+    schedule_rows = [
+        {"Date": date(2023, 1, 1), "Day": "Mon", "Shift1": "A"},
+        {"Date": date(2023, 1, 2), "Day": "Tue", "Shift1": "A"},
+    ]
+    stats = {
+        "A": {"Shift1": {"total": 2, "weekend": 0}},
+        "B": {"Shift1": {"total": 0, "weekend": 0}},
+    }
+    points_assigned = {"A": 2, "B": 0}
+    expected_points_total = {"A": 1, "B": 1}
+    last_assigned = {"A": date(2023, 1, 2), "B": None}
+
+    scheduler.balance_points(
+        schedule_rows,
+        stats,
+        shift_cfg_map,
+        expected_points_total,
+        points_assigned,
+        st.session_state.min_gap,
+        ["Shift1"],
+        last_assigned,
+    )
+
+    assigned = [row["Shift1"] for row in schedule_rows]
+    assert set(assigned) == {"A", "B"}
+    assert points_assigned == {"A": 1, "B": 1}
 


### PR DESCRIPTION
## Summary
- add `balance_points` function to redistribute shifts based on point totals
- call the function in `build_schedule`
- test new functionality
- fix stray character in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68725bc082dc83288f9515c284d0fea1