### PR TITLE
Simplify scheduler tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+import importlib
+import sys
+import types
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+
+class SessionState(dict):
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+
+
+class SimpleDataFrame:
+    def __init__(self, data=None, columns=None):
+        self._data = list(data) if data is not None else []
+        self.columns = columns or []
+
+    def __len__(self):
+        return len(self._data)
+
+    @property
+    def empty(self):
+        return len(self._data) == 0
+
+    def to_dict(self, orient="records"):
+        if orient != "records":
+            raise NotImplementedError
+        return list(self._data)
+
+
+def simple_date_range(start, end):
+    if not isinstance(start, datetime):
+        start = datetime.combine(start, datetime.min.time())
+    if not isinstance(end, datetime):
+        end = datetime.combine(end, datetime.min.time())
+    days = (end - start).days + 1
+    return [start + timedelta(days=i) for i in range(days)]
+
+
+class SimplePandasModule(types.SimpleNamespace):
+    def DataFrame(self, data=None, columns=None):
+        return SimpleDataFrame(data, columns)
+
+    def date_range(self, start, end):
+        return simple_date_range(start, end)
+
+
+@pytest.fixture(autouse=True)
+def stub_modules(monkeypatch):
+    st = types.SimpleNamespace(session_state=SessionState(), error=lambda *a, **k: None)
+    pd = SimplePandasModule()
+    monkeypatch.setitem(sys.modules, 'streamlit', st)
+    monkeypatch.setitem(sys.modules, 'pandas', pd)
+    root = Path(__file__).resolve().parent.parent
+    monkeypatch.syspath_prepend(str(root))
+    import scheduler
+    importlib.reload(scheduler)
+    yield st, scheduler
+    importlib.reload(scheduler)
+
+
+@pytest.fixture
+def simple_state(stub_modules):
+    st, _ = stub_modules
+    st.session_state.clear()
+    st.session_state.shifts = [
+        {
+            "label": "Shift1",
+            "role": "Junior",
+            "night_float": False,
+            "thur_weekend": False,
+            "points": 1.0,
+        }
+    ]
+    st.session_state.juniors = ["A", "B"]
+    st.session_state.seniors = []
+    st.session_state.nf_juniors = []
+    st.session_state.nf_seniors = []
+    st.session_state.leaves = []
+    st.session_state.rotators = []
+    st.session_state.extra_oncalls = {}
+    st.session_state.weights = {}
+    st.session_state.start_date = date(2023, 1, 1)
+    st.session_state.end_date = date(2023, 1, 2)
+    st.session_state.min_gap = 1
+    st.session_state.nf_block_length = 5
+    st.session_state.seed = 0
+    return st
+
+
+@pytest.fixture
+def sched(stub_modules):
+    _, scheduler = stub_modules
+    return scheduler

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,102 +1,21 @@
-import types
-import sys
-import os
-
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-# create minimal streamlit stub
-class SessionState(dict):
-    __getattr__ = dict.get
-    __setattr__ = dict.__setitem__
-
-st = types.SimpleNamespace(session_state=SessionState(), error=lambda *a, **k: None)
-sys.modules['streamlit'] = st
-
-# minimal pandas stub for tests
-class SimpleDataFrame:
-    def __init__(self, data=None, columns=None):
-        self._data = list(data) if data is not None else []
-        self.columns = columns or []
-
-    def __len__(self):
-        return len(self._data)
-
-    @property
-    def empty(self):
-        return len(self._data) == 0
-
-    def to_dict(self, orient="records"):
-        if orient != "records":
-            raise NotImplementedError
-        return list(self._data)
-
-
-class SimplePandasModule(types.SimpleNamespace):
-    def DataFrame(self, data=None, columns=None):
-        return SimpleDataFrame(data, columns)
-
-    def date_range(self, start, end):
-        from datetime import datetime, timedelta
-        if isinstance(start, datetime):
-            start_dt = start
-        else:
-            start_dt = datetime.combine(start, datetime.min.time())
-        if isinstance(end, datetime):
-            end_dt = end
-        else:
-            end_dt = datetime.combine(end, datetime.min.time())
-        days = (end_dt - start_dt).days + 1
-        return [start_dt + timedelta(days=i) for i in range(days)]
-
-
-sys.modules['pandas'] = SimplePandasModule()
-
 from datetime import date
-import scheduler
 
 
-def setup_state_simple():
-    st.session_state.clear()
-    st.session_state.shifts = [
-        {
-            "label": "Shift1",
-            "role": "Junior",
-            "night_float": False,
-            "thur_weekend": False,
-            "points": 1.0,
-        }
-    ]
-    st.session_state.juniors = ["A", "B"]
-    st.session_state.seniors = []
-    st.session_state.nf_juniors = []
-    st.session_state.nf_seniors = []
-    st.session_state.leaves = []
-    st.session_state.rotators = []
-    st.session_state.extra_oncalls = {}
-    st.session_state.weights = {}
-    st.session_state.start_date = date(2023, 1, 1)
-    st.session_state.end_date = date(2023, 1, 2)
-    st.session_state.min_gap = 1
-    st.session_state.nf_block_length = 5
-    st.session_state.seed = 0
-
-
-def test_allocate_integer_quotas_basic():
+def test_allocate_integer_quotas_basic(sched):
     quotas = {"A": 1.2, "B": 0.8}
-    result = scheduler.allocate_integer_quotas(quotas, 2)
+    result = sched.allocate_integer_quotas(quotas, 2)
     assert result == {"A": 1, "B": 1}
 
 
-def test_build_schedule_simple():
-    setup_state_simple()
-    df, wide, unf, compact = scheduler.build_schedule()
+def test_build_schedule_simple(sched, simple_state):
+    df, wide, unf, compact = sched.build_schedule()
     assert len(df) == 2
     assert unf.empty
     assert not wide.empty
     assert not compact.empty
 
 
-def test_build_expectation_report():
+def test_build_expectation_report(sched):
     data = [
         {
             "Name": "A",
@@ -117,24 +36,22 @@ def test_build_expectation_report():
             "Expected Points": 2,
         },
     ]
-    df = scheduler.pd.DataFrame(data)
-    report = scheduler.build_expectation_report(df)
+    df = sched.pd.DataFrame(data)
+    report = sched.build_expectation_report(df)
     assert len(report) == 4
 
 
-def test_weekend_filter_fallback():
-    setup_state_simple()
-    st.session_state.shifts[0]["thur_weekend"] = True
-    st.session_state.start_date = date(2023, 1, 5)
-    st.session_state.end_date = date(2023, 1, 5)
-    st.session_state.leaves = [("A", date(2023, 1, 5), date(2023, 1, 5))]
-    df, _, unf, _ = scheduler.build_schedule()
+def test_weekend_filter_fallback(sched, simple_state):
+    simple_state.session_state.shifts[0]["thur_weekend"] = True
+    simple_state.session_state.start_date = date(2023, 1, 5)
+    simple_state.session_state.end_date = date(2023, 1, 5)
+    simple_state.session_state.leaves = [("A", date(2023, 1, 5), date(2023, 1, 5))]
+    df, _, unf, _ = sched.build_schedule()
     assert unf.empty
     assert df._data[0]["Shift1"] == "B"
 
 
-=
-def test_fill_unassigned_shifts_prioritizes_deficit():
+def test_fill_unassigned_shifts_prioritizes_deficit(sched, simple_state):
     cfg = {
         "label": "Shift1",
         "role": "Junior",
@@ -160,7 +77,7 @@ def test_fill_unassigned_shifts_prioritizes_deficit():
     target_total = {"Shift1": {"A": 0, "B": 1}}
     target_weekend = {"Shift1": {"A": 0, "B": 1}}
 
-    new_unfilled = scheduler.fill_unassigned_shifts(
+    new_unfilled = sched.fill_unassigned_shifts(
         schedule_rows,
         stats,
         unfilled,


### PR DESCRIPTION
## Summary
- simplify tests by using fixtures in `conftest.py`
- use fixtures to stub out `streamlit` and `pandas` modules
- refactor individual tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68725beb06cc8328b41dd2e4173af1f2