### PR TITLE
Remove expectation report helper

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -442,38 +442,6 @@ def build_median_report(summary_df: pd.DataFrame, tol: int = 0):
     return pd.DataFrame(rows)
 
 
-def build_expectation_report(summary_df: pd.DataFrame, tol: int = 0) -> pd.DataFrame:
-    """Highlight deviations from expected totals, weekends and points."""
-    rows = []
-    records = summary_df.to_dict(orient="records")
-    if not records:
-        return pd.DataFrame(rows)
-
-    cols = getattr(summary_df, "columns", None) or list(records[0].keys())
-    for col in [c for c in cols if c.endswith("_assigned_total")]:
-        label = col.replace("_assigned_total", "")
-        for r in records:
-            d_tot = r[f"{label}_assigned_total"] - r[f"{label}_expected_total"]
-            d_wkd = r[f"{label}_assigned_weekend"] - r[f"{label}_expected_weekend"]
-            if abs(d_tot) > tol or abs(d_wkd) > tol:
-                rows.append({
-                    "Name": r["Name"],
-                    "Label": label,
-                    "Δ Total vs expected": int(d_tot),
-                    "Δ Weekend vs expected": int(d_wkd),
-                })
-    if "Assigned Points" in cols and "Expected Points" in cols:
-        for r in records:
-            d_pts = r["Assigned Points"] - r["Expected Points"]
-            if abs(d_pts) > tol:
-                rows.append({
-                    "Name": r["Name"],
-                    "Label": "Points",
-                    "Δ Points vs expected": int(d_pts),
-                })
-    return pd.DataFrame(rows)
-
-
 def build_schedule(group_by: str | None = None):
     shifts_cfg = st.session_state.shifts
     start, end = st.session_state.start_date, st.session_state.end_date

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,33 +1,6 @@
 from datetime import date
 
 
-def setup_state_simple():
-    import streamlit as st
-    st.session_state.clear()
-    st.session_state.shifts = [
-        {
-            "label": "Shift1",
-            "role": "Junior",
-            "night_float": False,
-            "thur_weekend": False,
-            "points": 1.0,
-        }
-    ]
-    st.session_state.juniors = ["A", "B"]
-    st.session_state.seniors = []
-    st.session_state.nf_juniors = []
-    st.session_state.nf_seniors = []
-    st.session_state.leaves = []
-    st.session_state.rotators = []
-    st.session_state.extra_oncalls = {}
-    st.session_state.weights = {}
-    st.session_state.start_date = date(2023, 1, 1)
-    st.session_state.end_date = date(2023, 1, 2)
-    st.session_state.min_gap = 1
-    st.session_state.nf_block_length = 5
-    st.session_state.seed = 0
-
-
 def test_allocate_integer_quotas_basic(sched):
     quotas = {"A": 1.2, "B": 0.8}
     result = sched.allocate_integer_quotas(quotas, 2)
@@ -40,32 +13,6 @@ def test_build_schedule_simple(sched, simple_state):
     assert unf.empty
     assert not wide.empty
     assert not compact.empty
-
-
-def test_build_expectation_report(sched):
-    data = [
-        {
-            "Name": "A",
-            "Shift1_assigned_total": 2,
-            "Shift1_expected_total": 1,
-            "Shift1_assigned_weekend": 1,
-            "Shift1_expected_weekend": 0,
-            "Assigned Points": 3,
-            "Expected Points": 1,
-        },
-        {
-            "Name": "B",
-            "Shift1_assigned_total": 0,
-            "Shift1_expected_total": 1,
-            "Shift1_assigned_weekend": 0,
-            "Shift1_expected_weekend": 1,
-            "Assigned Points": 0,
-            "Expected Points": 2,
-        },
-    ]
-    df = sched.pd.DataFrame(data)
-    report = sched.build_expectation_report(df)
-    assert len(report) == 4
 
 
 def test_weekend_filter_fallback(sched, simple_state):
@@ -125,10 +72,8 @@ def test_fill_unassigned_shifts_prioritizes_deficit(sched, simple_state):
     assert schedule_rows[0]["Shift1"] == "B"
 
 
-def test_balance_points_basic(sched):
-    import streamlit as st
-    setup_state_simple()
-    cfg = st.session_state.shifts[0]
+def test_balance_points_basic(sched, simple_state):
+    cfg = simple_state.session_state.shifts[0]
 
     shift_cfg_map = {"Shift1": cfg}
     schedule_rows = [


### PR DESCRIPTION
## Summary
- drop the unused `build_expectation_report` helper
- remove the associated unit test
- fix `test_balance_points_basic` to use the `simple_state` fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726981b09c8328bc4616221e6ab724