### PR TITLE
Update fallback solver clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
+# Idea Gold Scheduler
 
+This project builds on OR-Tools to generate fair on-call schedules. Install `ortools` from the requirements file to enable the CP-SAT optimiser.
+
+If `ortools` is missing, the stub solver marks all shifts as **Unfilled**. This ensures the app still runs but signals that optimisation isn't available.

--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -52,17 +52,18 @@ except Exception:  # pragma: no cover - simple fallback if ortools missing
             self.parameters.max_time_in_seconds = 0
 
         def Solve(self, model):
-            # Dummy assignment: select first option for each constraint
+            # Dummy assignment: mark every shift as unfilled
             if hasattr(model, 'vars'):
                 people = model.people
                 days = model.days
                 shifts = model.shifts
+                unfilled_idx = len(people) - 1
                 for d_idx in range(len(days)):
                     for s_idx in range(len(shifts)):
                         for p_idx in range(len(people)):
                             v = model.vars[(p_idx, d_idx, s_idx)]
                             v.value = 0
-                        model.vars[(0, d_idx, s_idx)].value = 1
+                        model.vars[(unfilled_idx, d_idx, s_idx)].value = 1
             return self.OPTIMAL
 
         def Value(self, var):


### PR DESCRIPTION
## Summary
- improve fallback solver to mark all shifts as Unfilled when OR-Tools isn't installed
- document OR-Tools requirement and fallback behaviour in README

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68727bfce888832881085aa76986c088