### PR TITLE
Ensure compatibility with strict CpModel implementations

### DIFF
--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -83,11 +83,15 @@ class SchedulerSolver:
         self.shifts = data.shifts
         self.vars: Dict[Tuple[int, int, int], object] = {}
         self.build_variables()
-        # expose internals for stub solver
-        self.model.people = self.people
-        self.model.days = self.days
-        self.model.shifts = self.shifts
-        self.model.vars = self.vars
+        # expose internals for stub solver (may fail on real CpModel)
+        try:
+            self.model.people = self.people
+            self.model.days = self.days
+            self.model.shifts = self.shifts
+            self.model.vars = self.vars
+        except AttributeError:
+            # Real ortools model does not allow setting new attributes
+            pass
         self.add_constraints()
         self.build_objective()
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -23,3 +23,64 @@ def test_simple_schedule():
     df = build_schedule(data)
     assert len(df) == 2
     assert set(df["Shift1"]) <= {"A", "B", "Unfilled"}
+
+
+def test_schedule_with_strict_cpmodel(monkeypatch):
+    """Scheduler should not fail if CpModel disallows new attributes."""
+
+    from model import optimiser as opt
+
+    class _Var:
+        __slots__ = ("value",)
+
+        def __init__(self):
+            self.value = 0
+
+        def __add__(self, other):
+            if isinstance(other, _Var):
+                return self.value + other.value
+            return self.value + other
+
+        __radd__ = __add__
+
+    class StrictModel:
+        __slots__ = ()
+
+        def NewBoolVar(self, name):
+            return _Var()
+
+        def Add(self, constraint):
+            pass
+
+        def NewIntVar(self, a, b, name):
+            return _Var()
+
+        def Minimize(self, expr):
+            pass
+
+    class StubSolver(opt.cp_model.CpSolver):
+        pass
+
+    stub_cp_model = type(
+        "cp_model",
+        (),
+        {"CpModel": StrictModel, "CpSolver": StubSolver, "OPTIMAL": 0, "FEASIBLE": 0},
+    )
+
+    monkeypatch.setattr(opt, "cp_model", stub_cp_model)
+
+    data = InputData(
+        start_date=date(2023, 1, 1),
+        end_date=date(2023, 1, 1),
+        shifts=[ShiftTemplate(label="S1", role="Junior", night_float=False, thu_weekend=False)],
+        juniors=["A"],
+        seniors=[],
+        nf_juniors=[],
+        nf_seniors=[],
+        leaves=[],
+        rotators=[],
+        min_gap=1,
+    )
+
+    df = opt.build_schedule(data)
+    assert len(df) == 1


### PR DESCRIPTION
## Summary
- avoid setting custom attributes on `CpModel` objects
- add test to simulate strict CpModel that forbids new attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727b5b0e6883288b15d08a6bcf2055