### PR TITLE
Improve layout and use environment-aware time limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 
 from model.data_models import ShiftTemplate, InputData
 from model.optimiser import build_schedule
+import os
 
 st.set_page_config(page_title="Idea Gold Scheduler", layout="wide")
 st.title("Idea Gold Scheduler – CP-SAT")
@@ -20,28 +21,31 @@ if "nf_juniors" not in st.session_state:
 if "nf_seniors" not in st.session_state:
     st.session_state.nf_seniors = []
 
-st.sidebar.header("Configuration")
+st.header("Configuration")
 
-with st.sidebar.expander("Shift Templates"):
+with st.expander("Shift Templates", expanded=True):
     label = st.text_input("Label")
     role = st.selectbox("Role", ["Junior", "Senior"])
     nf = st.checkbox("Night Float")
     thu_wk = st.checkbox("Thu counts as weekend")
     points = st.number_input("Points", 1.0, 10.0, 1.0, 0.5)
-    if st.button("Add Shift"):
+    if st.button("Add Shift", key="add_shift"):
         st.session_state.shifts.append(
             ShiftTemplate(label=label, role=role, night_float=nf, thu_weekend=thu_wk, points=points)
         )
     if st.session_state.shifts:
         st.table(pd.DataFrame([s.__dict__ for s in st.session_state.shifts]))
 
-with st.sidebar.expander("Participants"):
+cols = st.columns(2)
+with cols[0]:
+    st.subheader("Participants")
     juniors_text = st.text_area("Juniors", "\n".join(st.session_state.juniors))
     seniors_text = st.text_area("Seniors", "\n".join(st.session_state.seniors))
     st.session_state.juniors = [n.strip() for n in juniors_text.splitlines() if n.strip()]
     st.session_state.seniors = [n.strip() for n in seniors_text.splitlines() if n.strip()]
 
-with st.sidebar.expander("Night Float Eligible"):
+with cols[1]:
+    st.subheader("Night Float Eligible")
     st.session_state.nf_juniors = st.multiselect(
         "Juniors", st.session_state.juniors, default=st.session_state.nf_juniors
     )
@@ -49,9 +53,12 @@ with st.sidebar.expander("Night Float Eligible"):
         "Seniors", st.session_state.seniors, default=st.session_state.nf_seniors
     )
 
-start_date = st.sidebar.date_input("Start Date", date.today())
-end_date = st.sidebar.date_input("End Date", date.today() + timedelta(days=27))
-min_gap = st.sidebar.slider("Minimum Gap", 0, 7, 1)
+date_cols = st.columns(2)
+with date_cols[0]:
+    start_date = st.date_input("Start Date", date.today())
+with date_cols[1]:
+    end_date = st.date_input("End Date", date.today() + timedelta(days=27))
+min_gap = st.slider("Minimum Gap", 0, 7, 1)
 
 if st.button("Generate Schedule"):
     data = InputData(
@@ -67,7 +74,9 @@ if st.button("Generate Schedule"):
         min_gap=min_gap,
     )
     try:
-        df = build_schedule(data)
+        env = os.getenv("APP_ENV", "dev")
+        limits = {"dev": 30, "test": 1, "prod": 60}
+        df = build_schedule(data, time_limit_sec=limits.get(env, 60))
         st.dataframe(df)
     except Exception as e:
         st.error(str(e))

--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -139,7 +139,7 @@ class SchedulerSolver:
         return pd.DataFrame(rows)
 
 
-def build_schedule(data: InputData) -> pd.DataFrame:
+def build_schedule(data: InputData, time_limit_sec: int | None = 60) -> pd.DataFrame:
     solver = SchedulerSolver(data)
-    return solver.solve(time_limit_sec=60)
+    return solver.solve(time_limit_sec=time_limit_sec)
 


### PR DESCRIPTION
## Summary
- widen the configuration UI by moving controls out of the sidebar
- select solver time limit based on APP_ENV
- make `build_schedule` accept a custom time limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727ef63a408328aa054f7fc096c6a3