### PR TITLE
Improve scheduling constraints and env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 This project builds on OR-Tools to generate fair on-call schedules. Install `ortools` from the requirements file to enable the CP-SAT optimiser.
 
 If `ortools` is missing, the stub solver marks all shifts as **Unfilled**. This ensures the app still runs but signals that optimisation isn't available.
+
+The time limit for solving depends on the environment. Set the `ENV` variable to
+`dev`, `test`, or `prod` (default) for 10s, 1s or 60s respectively.

--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import os
 from typing import Dict, Tuple
 
 try:
@@ -129,12 +130,43 @@ class SchedulerSolver:
                         f"x_{p_idx}_{d_idx}_{s_idx}")
 
     def add_constraints(self) -> None:
-        for d_idx in range(len(self.days)):
-            for s_idx in range(len(self.shifts)):
+        for d_idx, day in enumerate(self.days):
+            for s_idx, shift in enumerate(self.shifts):
+                # exactly one assignment per slot
                 self.model.Add(
                     sum(self.vars[(p_idx, d_idx, s_idx)]
                         for p_idx in range(len(self.people))) == 1
                 )
+                for p_idx, person in enumerate(self.people[:-1]):  # exclude Unfilled
+                    # role eligibility
+                    if shift.role == "Junior" and person not in self.data.juniors:
+                        self.model.Add(self.vars[(p_idx, d_idx, s_idx)] == 0)
+                    if shift.role == "Senior" and person not in self.data.seniors:
+                        self.model.Add(self.vars[(p_idx, d_idx, s_idx)] == 0)
+                    # night float eligibility
+                    if shift.night_float:
+                        if shift.role == "Junior" and person not in self.data.nf_juniors:
+                            self.model.Add(self.vars[(p_idx, d_idx, s_idx)] == 0)
+                        if shift.role == "Senior" and person not in self.data.nf_seniors:
+                            self.model.Add(self.vars[(p_idx, d_idx, s_idx)] == 0)
+                    # leaves
+                    for res, start, end in self.data.leaves:
+                        if res == person and start <= day <= end:
+                            self.model.Add(self.vars[(p_idx, d_idx, s_idx)] == 0)
+
+        # min_gap spacing
+        gap = self.data.min_gap
+        if gap > 0:
+            for p_idx, _ in enumerate(self.people[:-1]):  # exclude Unfilled
+                for d1_idx, day1 in enumerate(self.days):
+                    for d2_idx in range(d1_idx + 1, len(self.days)):
+                        if (self.days[d2_idx] - day1).days < gap:
+                            for s1_idx in range(len(self.shifts)):
+                                for s2_idx in range(len(self.shifts)):
+                                    self.model.Add(
+                                        self.vars[(p_idx, d1_idx, s1_idx)] +
+                                        self.vars[(p_idx, d2_idx, s2_idx)] <= 1
+                                    )
 
     def build_objective(self) -> None:
         # Simplified: just minimise unfilled slots
@@ -167,7 +199,15 @@ class SchedulerSolver:
         return pd.DataFrame(rows)
 
 
-def build_schedule(data: InputData) -> pd.DataFrame:
+def build_schedule(data: InputData, env: str | None = None) -> pd.DataFrame:
+    """Build schedule with optional environment based time limit."""
     solver = SchedulerSolver(data)
-    return solver.solve(time_limit_sec=60)
+    env = env or os.environ.get("ENV", "prod").lower()
+    if env == "dev":
+        limit = 10
+    elif env == "test":
+        limit = 1
+    else:
+        limit = 60
+    return solver.solve(time_limit_sec=limit)
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -84,3 +84,22 @@ def test_schedule_with_strict_cpmodel(monkeypatch):
 
     df = opt.build_schedule(data)
     assert len(df) == 1
+
+
+def test_role_and_gap_constraints():
+    data = InputData(
+        start_date=date(2023, 1, 1),
+        end_date=date(2023, 1, 2),
+        shifts=[ShiftTemplate(label="S1", role="Senior", night_float=True, thu_weekend=False)],
+        juniors=["A"],
+        seniors=["B"],
+        nf_juniors=["A"],
+        nf_seniors=[],  # B cannot cover night float
+        leaves=[],
+        rotators=[],
+        min_gap=2,
+    )
+
+    df = build_schedule(data)
+    # Only unfilled is eligible due to NF restriction; also min_gap prevents A working both days
+    assert set(df["S1"]) == {"Unfilled"}


### PR DESCRIPTION
## Summary
- enforce role, night-float and leave constraints
- respect minimum gap between shifts
- adjust solve time via ENV variable
- document ENV usage
- test added constraints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727fa504488328abb5da0bc806b293