### PR TITLE
Fix schedule build call

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,9 +81,8 @@ if st.button("Generate Schedule"):
         min_gap=min_gap,
     )
     try:
-        env = os.getenv("APP_ENV", "dev")
-        limits = {"dev": 30, "test": 1, "prod": 60}
-        df = build_schedule(data, time_limit_sec=limits.get(env, 60))
+        env = os.getenv("ENV", "dev")
+        df = build_schedule(data, env=env)
         st.dataframe(df)
     except Exception as e:
         st.error(str(e))


### PR DESCRIPTION
## Summary
- pass environment string when building schedule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872823541b48328bd4f2c033173fd71