### PR TITLE
Add test mode demo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ If `ortools` is missing, the stub solver marks all shifts as **Unfilled**. This 
 
 The time limit for solving depends on the environment. Set the `ENV` variable to
 `dev`, `test`, or `prod` (default) for 10s, 1s or 60s respectively.
+Enable the **Test mode** checkbox in the app to load example shifts and participant names automatically.

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 
 from model.data_models import ShiftTemplate, InputData
 from model.optimiser import build_schedule
+from model.demo_data import sample_shifts, sample_names
 import os
 
 st.set_page_config(page_title="Idea Gold Scheduler", layout="wide")
@@ -20,6 +21,19 @@ if "nf_juniors" not in st.session_state:
     st.session_state.nf_juniors = []
 if "nf_seniors" not in st.session_state:
     st.session_state.nf_seniors = []
+if "demo_loaded" not in st.session_state:
+    st.session_state.demo_loaded = False
+
+# optional sample data for quick testing
+test_mode = st.checkbox("Test mode (preload example data)")
+if test_mode and not st.session_state.demo_loaded:
+    st.session_state.shifts = sample_shifts()
+    juniors, seniors = sample_names()
+    st.session_state.juniors = juniors
+    st.session_state.seniors = seniors
+    st.session_state.nf_juniors = juniors[:]
+    st.session_state.nf_seniors = seniors[:]
+    st.session_state.demo_loaded = True
 
 st.header("Configuration")
 

--- a/model/demo_data.py
+++ b/model/demo_data.py
@@ -1,0 +1,24 @@
+from .data_models import ShiftTemplate
+
+
+def sample_shifts():
+    """Return preset shift templates for test mode."""
+    return [
+        ShiftTemplate(label="Junior night float", role="Junior", night_float=True, thu_weekend=False),
+        ShiftTemplate(label="Senior night float", role="Senior", night_float=True, thu_weekend=False),
+        ShiftTemplate(label="ER night", role="Junior", night_float=False, thu_weekend=True),
+        ShiftTemplate(label="Ward night", role="Junior", night_float=False, thu_weekend=True),
+        ShiftTemplate(label="Senior night", role="Senior", night_float=False, thu_weekend=True),
+        ShiftTemplate(label="evening shift", role="Senior", night_float=False, thu_weekend=False),
+        ShiftTemplate(label="morning shift", role="Senior", night_float=False, thu_weekend=False),
+        ShiftTemplate(label="Ward morning", role="Junior", night_float=False, thu_weekend=False),
+        ShiftTemplate(label="ER zone 1 morning", role="Junior", night_float=False, thu_weekend=False),
+        ShiftTemplate(label="ER zone 2 morning", role="Junior", night_float=False, thu_weekend=False),
+    ]
+
+
+def sample_names():
+    """Return lists of 30 junior and 15 senior names."""
+    juniors = [f"Junior {i}" for i in range(1, 31)]
+    seniors = [f"Senior {i}" for i in range(1, 16)]
+    return juniors, seniors


### PR DESCRIPTION
## Summary
- add demo data helpers
- allow UI to preload sample shifts and names when test mode is enabled
- mention new feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687283a72e44832880334eecd84b8a09