### PR TITLE
Ensure min_gap constraint after solve

### DIFF
--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -209,6 +209,28 @@ def build_schedule(data: InputData, env: str | None = None) -> pd.DataFrame:
         limit = 1
     else:
         limit = 60
-    return solver.solve(time_limit_sec=limit)
+    df = solver.solve(time_limit_sec=limit)
+    if not respects_min_gap(df, data.min_gap):
+        raise RuntimeError("Schedule violates min_gap constraint")
+    return df
+
+
+def respects_min_gap(df: pd.DataFrame, gap: int) -> bool:
+    """Return True if no resident appears on days closer than ``gap``."""
+    if gap <= 0:
+        return True
+    assignments: Dict[str, list] = {}
+    for row in df.to_dict("records"):
+        day = row.get("Date")
+        for label, person in row.items():
+            if label == "Date" or person in (None, "Unfilled"):
+                continue
+            assignments.setdefault(person, []).append(day)
+    for days in assignments.values():
+        days.sort()
+        for d1, d2 in zip(days, days[1:]):
+            if (d2 - d1).days < gap:
+                return False
+    return True
 
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -1,10 +1,14 @@
 import sys, os
 from datetime import date
-
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+try:
+    import pandas as pd
+except Exception:
+    from model import optimiser as opt
+    pd = opt.pd
 
 from model.data_models import ShiftTemplate, InputData
-from model.optimiser import build_schedule
+from model.optimiser import build_schedule, respects_min_gap
 
 
 def test_simple_schedule():
@@ -103,3 +107,17 @@ def test_role_and_gap_constraints():
     df = build_schedule(data)
     # Only unfilled is eligible due to NF restriction; also min_gap prevents A working both days
     assert set(df["S1"]) == {"Unfilled"}
+
+
+def test_respects_min_gap_function():
+    df = pd.DataFrame([
+        {"Date": date(2023, 1, 1), "S1": "A"},
+        {"Date": date(2023, 1, 2), "S1": "A"},
+    ])
+    assert not respects_min_gap(df, 2)
+
+    df = pd.DataFrame([
+        {"Date": date(2023, 1, 1), "S1": "A"},
+        {"Date": date(2023, 1, 3), "S1": "A"},
+    ])
+    assert respects_min_gap(df, 2)


### PR DESCRIPTION
## Summary
- validate solver output against the minimum gap requirement
- expose `respects_min_gap` helper
- test helper logic and call it in schedule build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687283f42d148328b46a0428bfc8582e