### PR TITLE
Implement fairness deviations with weighted objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ If `ortools` is missing, the stub solver marks all shifts as **Unfilled**. This 
 The time limit for solving depends on the environment. Set the `ENV` variable to
 `dev`, `test`, or `prod` (default) for 10s, 1s or 60s respectively.
 Enable the **Test mode** checkbox in the app to load example shifts and participant names automatically.
+The solver supports fractional fairness targets via `InputData.target_total`, `target_label`, and `target_weekend`. It minimises the largest deviation from these targets before minimising smaller gaps and unfilled shifts. This keeps point totals balanced whenever possible.

--- a/Specs, always read before advancing
+++ b/Specs, always read before advancing
@@ -129,6 +129,11 @@ Fairness deviations (should be ≤ 1 where feasible)
 CSV / JSON downloads.
 
 If the model is infeasible (e.g. constraints too tight), UI displays solver status and highlights which rule failed.
+Implementation Progress (2025-07)
+- Added deviation variables for per-label, total, and weekend points
+- Objective now minimises the largest deviation before smaller gaps and unfilled shifts
+- `InputData` gained optional targets for these values
+
 
 7 Outstanding / Future Work
 UI seed control & load/save configuration JSON.

--- a/model/data_models.py
+++ b/model/data_models.py
@@ -26,4 +26,7 @@ class InputData:
     min_gap: int = 1
     nf_block_length: int = 5
     extra_oncalls: Dict[str, int] | None = None
+    target_label: Dict[tuple[str, str], float] | None = None
+    target_total: float | None = None
+    target_weekend: Dict[str, float] | None = None
 


### PR DESCRIPTION
## Summary
- extend `InputData` for fractional fairness targets
- expand fallback `_Var` math operations
- compute point totals and deviation variables in `SchedulerSolver`
- add weighted objective minimizing deviations lexicographically
- include tests for balanced and minimal-deviation schedules
- document fairness objective in README and specs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68728a93c6ac83288bee9e52a2a83936