### PR TITLE
Fix night float block enforcement

### DIFF
--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -319,19 +319,31 @@ class SchedulerSolver:
                                         self.vars[(p_idx, d2_idx, s2_idx)] <= 1
                                     )
 
-        # night float blocks must be contiguous
+        # night float blocks must have exact length
         block_len = self.data.nf_block_length
         if block_len > 1:
             nf_shift_idxs = [i for i, s in enumerate(self.shifts) if s.night_float]
             for s_idx in nf_shift_idxs:
                 for block_start in range(0, len(self.days), block_len):
                     block_days = list(range(block_start, min(block_start + block_len, len(self.days))))
-                    if len(block_days) <= 1:
+                    if len(block_days) < block_len:
+                        for d_idx in block_days:
+                            for p_idx in range(len(self.people) - 1):
+                                self.model.Add(self.vars[(p_idx, d_idx, s_idx)] == 0)
                         continue
                     for p_idx in range(len(self.people)):
                         first_var = self.vars[(p_idx, block_days[0], s_idx)]
                         for d_idx in block_days[1:]:
                             self.model.Add(first_var == self.vars[(p_idx, d_idx, s_idx)])
+                for boundary in range(block_len, len(self.days), block_len):
+                    if boundary >= len(self.days):
+                        break
+                    prev_day = boundary - 1
+                    next_day = boundary
+                    for p_idx in range(len(self.people)):
+                        self.model.Add(
+                            self.vars[(p_idx, prev_day, s_idx)] + self.vars[(p_idx, next_day, s_idx)] <= 1
+                        )
 
     def build_objective(self) -> None:
         unfilled_vars = [

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -148,6 +148,28 @@ def test_respects_nf_blocks_function():
     assert not respects_nf_blocks(df, 3, shifts)
 
 
+def test_nf_blocks_exact_assignment():
+    data = InputData(
+        start_date=date(2023, 1, 1),
+        end_date=date(2023, 1, 3),
+        shifts=[ShiftTemplate(label="NF", role="Junior", night_float=True, thu_weekend=False)],
+        juniors=["A"],
+        seniors=[],
+        nf_juniors=["A"],
+        nf_seniors=[],
+        leaves=[],
+        rotators=[],
+        min_gap=0,
+        nf_block_length=2,
+    )
+
+    df = build_schedule(data, env="test")
+    rows = df.to_dict("records")
+    assert rows[2]["NF"] == "Unfilled"
+    assert rows[0]["NF"] == rows[1]["NF"]
+    assert respects_nf_blocks(df, 2, data.shifts)
+
+
 def _points_by_resident(df: pd.DataFrame, shifts: list[ShiftTemplate]) -> dict:
     pts: dict[str, float] = {}
     for row in df.to_dict("records"):


### PR DESCRIPTION
## Summary
- enforce exact `nf_block_length` runs within the optimiser
- disallow assignments in incomplete night-float blocks
- test for partial night-float blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0545761883289457a6bc6cae6c94