### PR TITLE
Use NF subsets in test mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,11 +28,11 @@ if "demo_loaded" not in st.session_state:
 test_mode = st.checkbox("Test mode (preload example data)")
 if test_mode and not st.session_state.demo_loaded:
     st.session_state.shifts = sample_shifts()
-    juniors, seniors = sample_names()
+    juniors, seniors, nf_juniors, nf_seniors = sample_names()
     st.session_state.juniors = juniors
     st.session_state.seniors = seniors
-    st.session_state.nf_juniors = juniors[:]
-    st.session_state.nf_seniors = seniors[:]
+    st.session_state.nf_juniors = nf_juniors
+    st.session_state.nf_seniors = nf_seniors
     st.session_state.demo_loaded = True
 
 st.header("Configuration")

--- a/model/demo_data.py
+++ b/model/demo_data.py
@@ -18,7 +18,7 @@ def sample_shifts():
 
 
 def sample_names():
-    """Return lists of 30 junior and 15 senior names."""
+    """Return demo participant lists and NF eligibility subsets."""
     juniors = [
         "Alice", "Ben", "Carla", "Derek", "Eva", "Frank", "Grace",
         "Hector", "Isla", "Jack", "Kira", "Liam", "Mia", "Noah", "Olivia",
@@ -30,4 +30,8 @@ def sample_names():
         "Leo", "Monica", "Nathan", "Opal", "Perry", "Ruth", "Simon", "Tanya",
     ]
 
-    return juniors, seniors
+    # Simple subsets to indicate night float eligibility
+    nf_juniors = juniors[:10]
+    nf_seniors = seniors[:5]
+
+    return juniors, seniors, nf_juniors, nf_seniors


### PR DESCRIPTION
## Summary
- extend `sample_names()` to provide NF eligibility subsets
- load those subsets when enabling test mode in the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a04e87adc83289bf40254b19cb629