### PR TITLE
Set prod as default ENV in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,7 @@ if st.button("Generate Schedule"):
         nf_block_length=nf_block_len,
     )
     try:
-        env = os.getenv("ENV", "dev")
+        env = os.getenv("ENV", "prod")
         df = build_schedule(data, env=env)
         st.dataframe(df)
     except Exception as e:


### PR DESCRIPTION
## Summary
- default `ENV` to `prod` in `app.py`
- keep `build_schedule` environment override mechanism

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4bab5b40832899bbcd71f8736830