### PR TITLE
Align min_gap validation with solver

### DIFF
--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -412,7 +412,7 @@ def build_schedule(data: InputData, env: str | None = None) -> pd.DataFrame:
 
 
 def respects_min_gap(df: pd.DataFrame, gap: int) -> bool:
-    """Return True if no resident appears on days closer than ``gap``."""
+    """Return True if no resident appears on days ``gap`` or fewer apart."""
     if gap <= 0:
         return True
     assignments: Dict[str, list] = {}
@@ -425,7 +425,7 @@ def respects_min_gap(df: pd.DataFrame, gap: int) -> bool:
     for days in assignments.values():
         days.sort()
         for d1, d2 in zip(days, days[1:]):
-            if (d2 - d1).days < gap:
+            if (d2 - d1).days <= gap:
                 return False
     return True
 

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -128,6 +128,12 @@ def test_respects_min_gap_function():
         {"Date": date(2023, 1, 1), "S1": "A"},
         {"Date": date(2023, 1, 3), "S1": "A"},
     ])
+    assert not respects_min_gap(df, 2)
+
+    df = pd.DataFrame([
+        {"Date": date(2023, 1, 1), "S1": "A"},
+        {"Date": date(2023, 1, 4), "S1": "A"},
+    ])
     assert respects_min_gap(df, 2)
 
 


### PR DESCRIPTION
## Summary
- ensure `respects_min_gap` treats differences equal to `gap` as violations
- expand unit tests for this edge case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4bafac1c8328bf3c6b928b5cad7a