### PR TITLE
Add day names in schedule output

### DIFF
--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -381,7 +381,7 @@ class SchedulerSolver:
             raise RuntimeError(f"Solver ended with status {name_func(status)}")
         rows = []
         for d_idx, day in enumerate(self.days):
-            row = {"Date": day}
+            row = {"Date": day, "Day": day.strftime("%A")}
             for s_idx, shift in enumerate(self.shifts):
                 assigned = None
                 for p_idx, person in enumerate(self.people):

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -28,6 +28,7 @@ def test_simple_schedule():
     df = build_schedule(data)
     assert len(df) == 2
     assert set(df["Shift1"]) <= {"A", "B", "Unfilled"}
+    assert list(df["Day"]) == ["Sunday", "Monday"]
 
 
 def test_schedule_with_strict_cpmodel(monkeypatch):


### PR DESCRIPTION
## Summary
- include a `Day` column when building the schedule
- validate `Day` column in existing optimiser test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5b79dfa88328b29c8a54613a5063