### PR TITLE
Add fairness log download option

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 
 from model.data_models import ShiftTemplate, InputData
 from model.optimiser import build_schedule
+from model.fairness import format_fairness_log
 from model.demo_data import sample_shifts, sample_names
 import os
 
@@ -100,5 +101,9 @@ if st.button("Generate Schedule"):
         env = os.getenv("ENV", "prod")
         df = build_schedule(data, env=env)
         st.dataframe(df)
+        log_text = format_fairness_log(df, data)
+        st.download_button("Download Fairness Log", log_text, file_name="fairness_log.txt")
+        if st.checkbox("Show Fairness Log"):
+            st.text(log_text)
     except Exception as e:
         st.error(str(e))

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,0 +1,4 @@
+from .optimiser import build_schedule, respects_min_gap
+from .nf_blocks import respects_nf_blocks
+from .fairness import format_fairness_log, calculate_points
+

--- a/model/fairness.py
+++ b/model/fairness.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List
+
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover - fallback when pandas missing
+    from . import optimiser as opt
+    pd = opt.pd
+
+from .data_models import ShiftTemplate, InputData
+
+__all__ = ["calculate_points", "format_fairness_log"]
+
+
+def _is_weekend(day: date, shift: ShiftTemplate) -> bool:
+    return day.weekday() >= 5 or (shift.thu_weekend and day.weekday() == 3)
+
+
+def calculate_points(df: pd.DataFrame, shifts: List[ShiftTemplate]) -> Dict[str, Dict[str, float]]:
+    """Return mapping of resident to total and weekend points per label."""
+    summary: Dict[str, Dict[str, float]] = {}
+    for row in df.to_dict("records"):
+        day = row.get("Date")
+        for sh in shifts:
+            person = row.get(sh.label)
+            if person in (None, "Unfilled"):
+                continue
+            info = summary.setdefault(person, {"total": 0.0, "weekend": 0.0, "labels": {}})
+            info["total"] += sh.points
+            info["labels"][sh.label] = info["labels"].get(sh.label, 0.0) + sh.points
+            if _is_weekend(day, sh):
+                info["weekend"] += sh.points
+    return summary
+
+
+def format_fairness_log(df: pd.DataFrame, data: InputData) -> str:
+    """Generate a human-readable fairness log."""
+    pts = calculate_points(df, data.shifts)
+    lines: List[str] = []
+    for person in sorted(pts):
+        info = pts[person]
+        line = f"{person}: total {info['total']:.1f}"
+        if data.target_total is not None:
+            dev = info['total'] - data.target_total
+            line += f" (dev {dev:+.1f})"
+        line += f", weekend {info['weekend']:.1f}"
+        if data.target_weekend and person in data.target_weekend:
+            wdev = info['weekend'] - data.target_weekend[person]
+            line += f" (dev {wdev:+.1f})"
+        for label in sorted(info['labels']):
+            val = info['labels'][label]
+            line += f", {label} {val:.1f}"
+            if data.target_label and (person, label) in data.target_label:
+                ldev = val - data.target_label[(person, label)]
+                line += f" (dev {ldev:+.1f})"
+        lines.append(line)
+    totals = [v['total'] for v in pts.values()]
+    if totals:
+        lines.append(f"Total point range: {max(totals) - min(totals):.1f}")
+    wk_totals = [v['weekend'] for v in pts.values()]
+    if wk_totals:
+        lines.append(f"Weekend point range: {max(wk_totals) - min(wk_totals):.1f}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- introduce `fairness.py` to calculate per-resident points and generate a log
- expose `format_fairness_log` via `model.__init__`
- update the Streamlit UI to let users download and view the fairness log

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a5e8887488328b155375f2441bb2f