### PR TITLE
Centralize pandas fallback

### DIFF
--- a/model/fairness.py
+++ b/model/fairness.py
@@ -6,8 +6,7 @@ from typing import Dict, List
 try:
     import pandas as pd
 except ImportError:  # pragma: no cover - fallback when pandas missing
-    from . import optimiser as opt
-    pd = opt.pd
+    from .pandas_stub import pd
 
 from .data_models import ShiftTemplate, InputData
 

--- a/model/nf_blocks.py
+++ b/model/nf_blocks.py
@@ -6,8 +6,7 @@ from typing import Dict, List
 try:
     import pandas as pd
 except ImportError:  # pragma: no cover - fallback when pandas missing
-    from . import optimiser as opt
-    pd = opt.pd
+    from .pandas_stub import pd
 
 from .data_models import ShiftTemplate
 

--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -5,17 +5,7 @@ from typing import Dict, Tuple
 try:
     import pandas as pd
 except ImportError:  # pragma: no cover - fallback when pandas missing
-    class SimpleDataFrame(list):
-        def __init__(self, data=None):
-            super().__init__(data or [])
-
-        def to_dict(self, orient="records"):
-            return list(self)
-
-        def __getitem__(self, key):
-            return [row.get(key) for row in self]
-
-    pd = type("pd", (), {"DataFrame": SimpleDataFrame})()
+    from .pandas_stub import pd
 
 try:
     from ortools.sat.python import cp_model

--- a/model/pandas_stub.py
+++ b/model/pandas_stub.py
@@ -1,0 +1,13 @@
+class SimpleDataFrame(list):
+    """Very small subset of pandas.DataFrame used for testing without pandas."""
+    def __init__(self, data=None):
+        super().__init__(data or [])
+
+    def to_dict(self, orient="records"):
+        return list(self)
+
+    def __getitem__(self, key):
+        return [row.get(key) for row in self]
+
+# Provide a minimal pd-like namespace
+pd = type("pd", (), {"DataFrame": SimpleDataFrame})()


### PR DESCRIPTION
## Summary
- add `pandas_stub.py` for pandas-free runs
- use the stub in `fairness.py`, `nf_blocks.py`, and `optimiser.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a639d0d0883289a05fe4704f9e9c2