### PR TITLE
Ensure fairness log lists all participants

### DIFF
--- a/model/fairness.py
+++ b/model/fairness.py
@@ -18,12 +18,15 @@ def _is_weekend(day: date, shift: ShiftTemplate) -> bool:
     return day.weekday() >= 5 or (shift.thu_weekend and day.weekday() == 3)
 
 
-def calculate_points(df: pd.DataFrame, shifts: List[ShiftTemplate]) -> Dict[str, Dict[str, float]]:
+def calculate_points(df: pd.DataFrame, data: InputData) -> Dict[str, Dict[str, float]]:
     """Return mapping of resident to total and weekend points per label."""
-    summary: Dict[str, Dict[str, float]] = {}
+    summary: Dict[str, Dict[str, float]] = {
+        name: {"total": 0.0, "weekend": 0.0, "labels": {}}
+        for name in data.juniors + data.seniors
+    }
     for row in df.to_dict("records"):
         day = row.get("Date")
-        for sh in shifts:
+        for sh in data.shifts:
             person = row.get(sh.label)
             if person in (None, "Unfilled"):
                 continue
@@ -37,7 +40,7 @@ def calculate_points(df: pd.DataFrame, shifts: List[ShiftTemplate]) -> Dict[str,
 
 def format_fairness_log(df: pd.DataFrame, data: InputData) -> str:
     """Generate a human-readable fairness log."""
-    pts = calculate_points(df, data.shifts)
+    pts = calculate_points(df, data)
     lines: List[str] = []
     for person in sorted(pts):
         info = pts[person]

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -258,3 +258,28 @@ def test_total_points_balanced_multiple_shifts(balanced_cp):
     df = opt.build_schedule(data, env="test")
     pts = _points_by_resident(df, shifts)
     assert abs(pts.get("A", 0) - pts.get("B", 0)) <= 1
+
+
+def test_fairness_log_includes_unused_resident():
+    from model.fairness import format_fairness_log
+
+    data = InputData(
+        start_date=date(2023, 1, 1),
+        end_date=date(2023, 1, 2),
+        shifts=[ShiftTemplate(label="S", role="Junior", night_float=False, thu_weekend=False, points=1.0)],
+        juniors=["A", "B"],
+        seniors=[],
+        nf_juniors=[],
+        nf_seniors=[],
+        leaves=[],
+        rotators=[],
+        min_gap=0,
+    )
+    df = pd.DataFrame([
+        {"Date": date(2023, 1, 1), "S": "A"},
+        {"Date": date(2023, 1, 2), "S": "A"},
+    ])
+    log = format_fairness_log(df, data)
+    lines = log.splitlines()
+    assert any(line.startswith("A: total 2.0") for line in lines)
+    assert any(line.startswith("B: total 0.0") for line in lines)


### PR DESCRIPTION
## Summary
- list all residents in fairness log even if they have no shifts
- verify unused participant gets `total 0.0` in log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a63a6ab1c83289b24e4a590424845