### PR TITLE
Move weekend check to utils

### DIFF
--- a/model/fairness.py
+++ b/model/fairness.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import date
 from typing import Dict, List
 
 try:
@@ -9,12 +8,9 @@ except ImportError:  # pragma: no cover - fallback when pandas missing
     from .pandas_stub import pd
 
 from .data_models import ShiftTemplate, InputData
+from .utils import is_weekend
 
 __all__ = ["calculate_points", "format_fairness_log"]
-
-
-def _is_weekend(day: date, shift: ShiftTemplate) -> bool:
-    return day.weekday() >= 5 or (shift.thu_weekend and day.weekday() == 3)
 
 
 def calculate_points(df: pd.DataFrame, data: InputData) -> Dict[str, Dict[str, float]]:
@@ -32,7 +28,7 @@ def calculate_points(df: pd.DataFrame, data: InputData) -> Dict[str, Dict[str, f
             info = summary.setdefault(person, {"total": 0.0, "weekend": 0.0, "labels": {}})
             info["total"] += sh.points
             info["labels"][sh.label] = info["labels"].get(sh.label, 0.0) + sh.points
-            if _is_weekend(day, sh):
+            if is_weekend(day, sh):
                 info["weekend"] += sh.points
     return summary
 

--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -126,6 +126,7 @@ except ImportError:  # pragma: no cover - simple fallback if ortools missing
 
 from .data_models import InputData, ShiftTemplate
 from .nf_blocks import respects_nf_blocks
+from .utils import is_weekend
 
 
 class SchedulerSolver:
@@ -213,7 +214,7 @@ class SchedulerSolver:
             wk_parts = []
             for d_idx, day in enumerate(self.days):
                 for s_idx, sh in enumerate(self.shifts):
-                    if not self.is_weekend(day, sh):
+                    if not is_weekend(day, sh):
                         continue
                     coef = int(round(sh.points * scale))
                     wk_parts.append(self._mul(self.vars[(p_idx, d_idx, s_idx)], coef))
@@ -221,12 +222,6 @@ class SchedulerSolver:
             wvar = self.model.NewIntVar(0, max_val, f"weekendpts_{p_idx}")
             self.model.Add(wvar == wk_expr)
             self.weekend_pts[p_idx] = wvar
-
-    @staticmethod
-    def is_weekend(day, shift: ShiftTemplate) -> bool:
-        if day.weekday() >= 5:
-            return True
-        return shift.thu_weekend and day.weekday() == 3
 
     def add_deviation_constraints(self) -> None:
         scale = self.SCALE

--- a/model/utils.py
+++ b/model/utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from datetime import date
+
+from .data_models import ShiftTemplate
+
+__all__ = ["is_weekend"]
+
+
+def is_weekend(day: date, shift: ShiftTemplate) -> bool:
+    """Return True if the given day/shift counts as a weekend."""
+    return day.weekday() >= 5 or (shift.thu_weekend and day.weekday() == 3)

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -25,7 +25,19 @@ def _sample_df_and_shifts():
 
 def test_calculate_points():
     df, shifts = _sample_df_and_shifts()
-    pts = calculate_points(df, shifts)
+    data = InputData(
+        start_date=date(2023, 1, 7),
+        end_date=date(2023, 1, 8),
+        shifts=shifts,
+        juniors=["Alice", "Bob"],
+        seniors=[],
+        nf_juniors=[],
+        nf_seniors=[],
+        leaves=[],
+        rotators=[],
+        min_gap=1,
+    )
+    pts = calculate_points(df, data)
     assert pts == {
         "Alice": {"total": 3.0, "weekend": 3.0, "labels": {"D": 1.0, "N": 2.0}},
         "Bob": {"total": 3.0, "weekend": 3.0, "labels": {"D": 1.0, "N": 2.0}},


### PR DESCRIPTION
## Summary
- centralize weekend check into `model/utils.py`
- use helper in `fairness` and `optimiser`
- update fairness tests for new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a65d731a88328aaf6ce7af1740061