### PR TITLE
Improve fairness log with role & night float info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ The time limit for solving depends on the environment. Set the `ENV` variable to
 Enable the **Test mode** checkbox in the app to load example shifts and participant names automatically.
 The solver supports fractional fairness targets via `InputData.target_total`, `target_label`, and `target_weekend`. It minimises the largest deviation from these targets before minimising smaller gaps and unfilled shifts. This keeps point totals balanced whenever possible.
 
-The results page includes a **Download Fairness Log** button. It saves a text file summarising each resident's total and weekend points, along with any deviations from the targets you entered.
+The results page includes a **Download Fairness Log** button. It saves a text file summarising each resident's role, night float points, total and weekend points, along with any deviations from the targets you entered.

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -39,8 +39,18 @@ def test_calculate_points():
     )
     pts = calculate_points(df, data)
     assert pts == {
-        "Alice": {"total": 3.0, "weekend": 3.0, "labels": {"D": 1.0, "N": 2.0}},
-        "Bob": {"total": 3.0, "weekend": 3.0, "labels": {"D": 1.0, "N": 2.0}},
+        "Alice": {
+            "total": 3.0,
+            "weekend": 3.0,
+            "labels": {"D": 1.0, "N": 2.0},
+            "night_float": 0.0,
+        },
+        "Bob": {
+            "total": 3.0,
+            "weekend": 3.0,
+            "labels": {"D": 1.0, "N": 2.0},
+            "night_float": 0.0,
+        },
     }
 
 
@@ -61,8 +71,8 @@ def test_format_fairness_log():
     )
     log = format_fairness_log(df, data)
     expected_lines = [
-        "Alice: total 3.0 (dev +0.0), weekend 3.0, D 1.0, N 2.0",
-        "Bob: total 3.0 (dev +0.0), weekend 3.0, D 1.0, N 2.0",
+        "Alice (Junior, NF 0.0): total 3.0 (dev +0.0), weekend 3.0, D 1.0, N 2.0",
+        "Bob (Junior, NF 0.0): total 3.0 (dev +0.0), weekend 3.0, D 1.0, N 2.0",
         "Total point range: 0.0",
         "Weekend point range: 0.0",
     ]

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -281,5 +281,5 @@ def test_fairness_log_includes_unused_resident():
     ])
     log = format_fairness_log(df, data)
     lines = log.splitlines()
-    assert any(line.startswith("A: total 2.0") for line in lines)
-    assert any(line.startswith("B: total 0.0") for line in lines)
+    assert any(line.startswith("A (Junior, NF 0.0): total 2.0") for line in lines)
+    assert any(line.startswith("B (Junior, NF 0.0): total 0.0") for line in lines)


### PR DESCRIPTION
## Summary
- expand fairness calculations to track night float points
- include resident role and night float totals in the fairness log
- update README to reflect new log details
- update tests for the new log output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6a3ae3a08328b0d604db75996716