### PR TITLE
Remove unused extra_oncalls field

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ Enable the **Test mode** checkbox in the app to load example shifts and particip
 The solver supports fractional fairness targets via `InputData.target_total`, `target_label`, and `target_weekend`. It minimises the largest deviation from these targets before minimising smaller gaps and unfilled shifts. This keeps point totals balanced whenever possible.
 
 The results page includes a **Download Fairness Log** button. It saves a text file summarising each resident's role, night float points, total and weekend points, along with any deviations from the targets you entered.
+
+## Changelog
+- Removed unused `extra_oncalls` field from `InputData`.

--- a/Specs, always read before advancing
+++ b/Specs, always read before advancing
@@ -133,6 +133,7 @@ Implementation Progress (2025-07)
 - Added deviation variables for per-label, total, and weekend points
 - Objective now minimises the largest deviation before smaller gaps and unfilled shifts
 - `InputData` gained optional targets for these values
+- Removed unused `extra_oncalls` field from `InputData`
 
 
 7 Outstanding / Future Work

--- a/model/data_models.py
+++ b/model/data_models.py
@@ -25,7 +25,6 @@ class InputData:
     rotators: List[Tuple[str, date, date]]
     min_gap: int = 1
     nf_block_length: int = 5
-    extra_oncalls: Dict[str, int] | None = None
     target_label: Dict[tuple[str, str], float] | None = None
     target_total: float | None = None
     target_weekend: Dict[str, float] | None = None


### PR DESCRIPTION
## Summary
- clean up `InputData` dataclass by dropping the unused `extra_oncalls`
- note the change in the README changelog and implementation progress notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6efb234c8328b176bdc4e4f289d6