### PR TITLE
Auto-compute fairness targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,26 @@ The time limit for solving depends on the environment. Set the `ENV` variable to
 Enable the **Test mode** checkbox in the app to load example shifts and participant names automatically.
 The solver supports fractional fairness targets via `InputData.target_total`, `target_label`, and `target_weekend`. It minimises the largest deviation from these targets before minimising smaller gaps and unfilled shifts. This keeps point totals balanced whenever possible.
 
+If `target_total` or `target_weekend` are not provided, `build_schedule` calculates
+them automatically. It divides the total points and weekend points for the block
+evenly among all listed residents and assigns these values back on the `InputData`
+object before solving. For example:
+
+```python
+data = InputData(
+    start_date=date(2025, 1, 1),
+    end_date=date(2025, 1, 7),
+    shifts=[ShiftTemplate(label="D", role="Junior", night_float=False, thu_weekend=False, points=1.0)],
+    juniors=["A", "B"],
+    seniors=[],
+    nf_juniors=[],
+    nf_seniors=[],
+    leaves=[],
+    rotators=[],
+    min_gap=1,
+)
+schedule = build_schedule(data)
+# data.target_total and data.target_weekend now hold the computed shares
+```
+
 The results page includes a **Download Fairness Log** button. It saves a text file summarising each resident's role, night float points, total and weekend points, along with any deviations from the targets you entered.

--- a/Specs, always read before advancing
+++ b/Specs, always read before advancing
@@ -133,6 +133,7 @@ Implementation Progress (2025-07)
 - Added deviation variables for per-label, total, and weekend points
 - Objective now minimises the largest deviation before smaller gaps and unfilled shifts
 - `InputData` gained optional targets for these values
+- `build_schedule` computes default total and weekend targets when left unset
 
 
 7 Outstanding / Future Work

--- a/model/optimiser.py
+++ b/model/optimiser.py
@@ -380,6 +380,22 @@ class SchedulerSolver:
 
 def build_schedule(data: InputData, env: str | None = None) -> pd.DataFrame:
     """Build schedule with optional environment based time limit."""
+    participants = data.juniors + data.seniors
+    if participants:
+        days = (data.end_date - data.start_date).days + 1
+        total_points = days * sum(s.points for s in data.shifts)
+        weekend_points = 0.0
+        for i in range(days):
+            day = data.start_date + timedelta(days=i)
+            for s in data.shifts:
+                if is_weekend(day, s):
+                    weekend_points += s.points
+        if data.target_total is None:
+            data.target_total = total_points / len(participants)
+        if data.target_weekend is None:
+            share = weekend_points / len(participants)
+            data.target_weekend = {p: share for p in participants}
+
     solver = SchedulerSolver(data)
     env = env or os.environ.get("ENV", "prod").lower()
     if env == "dev":

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -291,3 +291,23 @@ def test_fairness_log_includes_unused_resident():
     lines = log.splitlines()
     assert any(line.startswith("A (Junior, NF 0.0): total 2.0") for line in lines)
     assert any(line.startswith("B (Junior, NF 0.0): total 0.0") for line in lines)
+
+
+def test_auto_target_computation():
+    data = InputData(
+        start_date=date(2023, 1, 2),
+        end_date=date(2023, 1, 2),
+        shifts=[ShiftTemplate(label="S", role="Junior", night_float=False, thu_weekend=False, points=1.0)],
+        juniors=["A", "B"],
+        seniors=[],
+        nf_juniors=[],
+        nf_seniors=[],
+        leaves=[],
+        rotators=[],
+        min_gap=0,
+    )
+    assert data.target_total is None
+    assert data.target_weekend is None
+    build_schedule(data, env="test")
+    assert data.target_total == 0.5
+    assert data.target_weekend == {"A": 0.0, "B": 0.0}


### PR DESCRIPTION
## Summary
- compute default fairness targets in `build_schedule`
- document automatic target calculation in README
- record progress in spec
- test auto target assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6ef317608328b97ae9b9d1cf99f8