### PR TITLE
Enhance fairness reporting and solver limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This project builds on OR-Tools to generate fair on-call schedules. Install `ortools` from the requirements file to enable the CP-SAT optimiser.
 
-If `ortools` is missing, the stub solver marks all shifts as **Unfilled**. This ensures the app still runs but signals that optimisation isn't available.
+If `ortools` is missing, the stub solver marks all shifts as **Unfilled** and the app shows a warning so you know optimisation isn't available.
 
-The time limit for solving depends on the environment. Set the `ENV` variable to
-`dev`, `test`, or `prod` (default) for 10s, 1s or 60s respectively.
+The time limit for solving depends on the environment and problem size. Set the `ENV` variable to
+`dev`, `test`, or `prod` (default) for base limits of 10s, 1s or 60s; the code scales these based on the number of participants, days, and shift templates to keep small runs quick.
 Enable the **Test mode** checkbox in the app to load example shifts and participant names automatically.
 The solver supports fractional fairness targets via `InputData.target_total`, `target_label`, and `target_weekend`. It minimises the largest deviation from these targets before minimising smaller gaps and unfilled shifts. This keeps point totals balanced whenever possible.
 
@@ -31,9 +31,11 @@ schedule = build_schedule(data)
 # data.target_total and data.target_weekend now hold the computed shares
 ```
 
-The results page includes a **Download Fairness Log** button. It saves a text file summarising each resident's role, night float points, total and weekend points, along with any deviations from the targets you entered.
+The results page includes a **Download Fairness Log** button. It saves a text file summarising each resident's role, night float points, total and weekend points, along with any deviations from the targets you entered. A Fairness summary also shows the min/max/range for total and weekend points directly in the UI.
 
 ## Changelog
 - Removed unused `extra_oncalls` field from `InputData`.
 - Added `docs/archive.txt` containing a read-only snapshot of all code and documentation.
 - Hardened the scheduler against stubbed CP-SAT implementations to keep tests and fallbacks working.
+- Added UI fairness summaries and stub-solver warning banner.
+- Scaled solver time limits by rough problem size to balance dev responsiveness with larger runs.

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from datetime import date, timedelta
 
 from model.data_models import ShiftTemplate, InputData
 from model.optimiser import build_schedule
-from model.fairness import format_fairness_log
+from model.fairness import calculate_points, fairness_range_lines, format_fairness_log
 from model.demo_data import sample_shifts, sample_names
 import os
 
@@ -100,8 +100,17 @@ if st.button("Generate Schedule"):
     try:
         env = os.getenv("ENV", "prod")
         df = build_schedule(data, env=env)
+        warning = df.attrs.get("solver_warning") if hasattr(df, "attrs") else None
+        if warning:
+            st.warning(warning)
+        points = calculate_points(df, data)
         st.dataframe(df)
-        log_text = format_fairness_log(df, data)
+        ranges = fairness_range_lines(points)
+        if ranges:
+            st.subheader("Fairness summary")
+            for line in ranges:
+                st.write(line)
+        log_text = format_fairness_log(df, data, points=points)
         st.download_button("Download Fairness Log", log_text, file_name="fairness_log.txt")
         if st.checkbox("Show Fairness Log"):
             st.text(log_text)

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -73,7 +73,7 @@ def test_format_fairness_log():
     expected_lines = [
         "Alice (Junior, NF 0.0): total 3.0 (dev +0.0), weekend 3.0, D 1.0, N 2.0",
         "Bob (Junior, NF 0.0): total 3.0 (dev +0.0), weekend 3.0, D 1.0, N 2.0",
-        "Total point range: 0.0",
-        "Weekend point range: 0.0",
+        "Total points min 3.0, max 3.0, range 0.0",
+        "Weekend points min 3.0, max 3.0, range 0.0",
     ]
     assert log.splitlines() == expected_lines


### PR DESCRIPTION
## Summary
- surface fairness range summaries in the UI and reuse shared helpers for the downloadable log
- warn when the stub solver is used, scale solver time limits by problem complexity, and document the behavior
- update tests for the new fairness log output

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207532f9dc8328aee227499b9e3f92)